### PR TITLE
fix(components): resolve field size typing and cleanup footer

### DIFF
--- a/src/components/admin/article-form.tsx
+++ b/src/components/admin/article-form.tsx
@@ -262,7 +262,8 @@ export function ArticleForm({
 
 /* ── Field primitives ─────────────────────────────────────────── */
 
-interface FieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface FieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size"> {
   label: string;
   index: string;
   hint?: string;

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -84,7 +84,6 @@ export function Footer() {
           <span>
             © {new Date().getFullYear()} AlamOps. {t.footer.rights}
           </span>
-          <span>{t.footer.madeWith}</span>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
- Adjust FieldProps to omit the native size attribute and avoid typing clashes with the custom size prop
- Remove the redundant “made with” footer text to align with current copy guidelines