### PR TITLE
feat(chat): surface Calendly CTA for booking calls

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export const metadata: Metadata = {
     "Terraform",
     "Consultoría DevOps",
     "Consultoría cloud",
-    "Consultoría multi-cloud Madrid",
+    "Consultoría multi-cloud Zaragoza",
     "Servicios cloud España",
   ],
   authors: [{ name: SITE_NAME, url: SITE_URL }],
@@ -125,7 +125,7 @@ const organizationJsonLd = {
   foundingDate: "2024",
   address: {
     "@type": "PostalAddress",
-    addressLocality: "Madrid",
+    addressLocality: "Zaragoza",
     addressCountry: "ES",
   },
   areaServed: [

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -150,7 +150,7 @@ export default function TermsOfServicePage() {
       <LegalSection id="jurisdiction" num="08" title="Law & Jurisdiction">
         <p>These terms are governed by Spanish and European legislation.</p>
         <p>
-          For any conflict, the courts of Madrid, Spain will be competent,
+          For any conflict, the courts of Zaragoza, Spain will be competent,
           unless applicable regulations provide otherwise.
         </p>
       </LegalSection>

--- a/src/components/chat-widget.tsx
+++ b/src/components/chat-widget.tsx
@@ -7,9 +7,10 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { ArrowUpRight, X } from "lucide-react";
+import { ArrowUpRight, CalendarClock, X } from "lucide-react";
 import { API_URL } from "@/lib/utils";
 import { useLocale } from "./locale-provider";
+import type { Dict } from "@/lib/i18n";
 
 type ChatRole = "user" | "bot";
 
@@ -21,6 +22,27 @@ interface ChatMessage {
 }
 
 const SESSION_KEY = "alamops_chat_session";
+const CALENDLY_URL = "https://calendly.com/ceo-alamops";
+
+const CTA_TRIGGERS: RegExp[] = [
+  /hablar con un? especialista/i,
+  /llamada estrat[ée]gica/i,
+  /agendar(la|\s+(una\s+)?(llamada|cita|reuni[oó]n))/i,
+  /(book|schedule).*(call|meeting|session)/i,
+  /talk to (a|an) (specialist|expert)/i,
+  /strategy call/i,
+];
+
+function hasCallCta(text: string): boolean {
+  return CTA_TRIGGERS.some((re) => re.test(text));
+}
+
+function cleanCtaLine(text: string): string {
+  return text
+    .replace(/^\s*[·•\-*]?\s*(hablar con un? especialista|talk to (a|an) (specialist|expert))\s*[→>»]*\s*$/gim, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
 
 function genId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -250,7 +272,7 @@ export function ChatWidget() {
           <IntroBlock />
 
           {messages.map((m) => (
-            <MessageBlock key={m.id} msg={m} botLabel={t.chat.bot} youLabel={t.chat.you} />
+            <MessageBlock key={m.id} msg={m} t={t} />
           ))}
 
           {sending && <TypingBlock label={t.chat.bot} />}
@@ -325,16 +347,11 @@ function IntroBlock() {
   );
 }
 
-function MessageBlock({
-  msg,
-  botLabel,
-  youLabel,
-}: {
-  msg: ChatMessage;
-  botLabel: string;
-  youLabel: string;
-}) {
+function MessageBlock({ msg, t }: { msg: ChatMessage; t: Dict }) {
   const isUser = msg.role === "user";
+  const showCta = !isUser && hasCallCta(msg.text);
+  const body = showCta ? cleanCtaLine(msg.text) : msg.text;
+
   return (
     <div
       className={[
@@ -344,7 +361,7 @@ function MessageBlock({
     >
       <div className="mono text-[10px] tracking-[0.3em] uppercase text-[#1a1a17]/50 flex items-center gap-2">
         {!isUser && <span className="inline-block w-4 h-px bg-[#5a6a3a]" />}
-        <span>{isUser ? youLabel : botLabel}</span>
+        <span>{isUser ? t.chat.you : t.chat.bot}</span>
         {isUser && <span className="inline-block w-4 h-px bg-[#1a1a17]/40" />}
       </div>
       <div
@@ -355,8 +372,27 @@ function MessageBlock({
             : "border-l-2 border-[#5a6a3a] pl-4 pr-1 py-1",
         ].join(" ")}
       >
-        {msg.text}
+        {body}
       </div>
+      {showCta && (
+        <a
+          href={CALENDLY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="alam-chat-cta mt-2 ml-[2px] inline-flex items-center gap-3 bg-[#5a6a3a] text-[#faf8f3] pl-4 pr-3 py-3 border border-[#5a6a3a] hover:bg-[#1a1a17] hover:border-[#1a1a17] transition-colors max-w-[88%]"
+        >
+          <CalendarClock className="w-4 h-4 shrink-0 stroke-[1.5]" aria-hidden />
+          <span className="flex flex-col items-start leading-tight">
+            <span className="mono text-[10px] tracking-[0.3em] uppercase">
+              {t.chat.cta.book}
+            </span>
+            <span className="text-[13px] tracking-tight opacity-85">
+              {t.chat.cta.bookHint}
+            </span>
+          </span>
+          <ArrowUpRight className="w-4 h-4 shrink-0 stroke-[1.5] ml-1" aria-hidden />
+        </a>
+      )}
     </div>
   );
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -175,7 +175,7 @@ export const dict = {
       values: {
         email: "support@alamops.com",
         phone: "+34 61 40 20 961",
-        office: "Madrid, España",
+        office: "Zaragoza, España",
       },
       urgentTitle: "Need help urgently?",
       urgentText: "Our on-call rotation handles critical incidents 24/7.",
@@ -232,6 +232,10 @@ export const dict = {
         rateLimit: "Too many messages. Try again in a minute.",
         offline: "Couldn't reach the server. Try again.",
         failed: "Something went wrong. Please retry.",
+      },
+      cta: {
+        book: "Book a call",
+        bookHint: "Free 30-min strategy session",
       },
     },
   },
@@ -385,7 +389,7 @@ export const dict = {
       values: {
         email: "support@alamops.com",
         phone: "+34 61 40 20 961",
-        office: "Madrid, España",
+        office: "Zaragoza, España",
       },
       urgentTitle: "¿Necesitas ayuda urgente?",
       urgentText:
@@ -443,6 +447,10 @@ export const dict = {
         rateLimit: "Demasiados mensajes. Inténtalo en un minuto.",
         offline: "No se pudo conectar al servidor. Inténtalo de nuevo.",
         failed: "Algo salió mal. Vuelve a intentarlo.",
+      },
+      cta: {
+        book: "Agendar llamada",
+        bookHint: "Sesión estratégica gratis de 30 min",
       },
     },
   },


### PR DESCRIPTION
- Detect call intent phrases in bot replies to show a Calendly CTA button
- Normalize CTA message text before rendering the booking link
- Provide localized CTA labels in English and Spanish dictionaries
- Replace Madrid references with Zaragoza in metadata, schema, and terms