### PR TITLE
feat(contact): shift urgent CTA to consultation booking

### DIFF
--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -198,7 +198,9 @@ export function ContactSection() {
                 {t.contact.urgentText}
               </p>
               <a
-                href="mailto:support@alamops.com?subject=URGENT"
+                href="https://calendly.com/ceo-alamops"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="mono text-[10px] tracking-[0.3em] uppercase border border-[#1a1a17]/30 px-4 py-2 hover:border-[#5a6a3a] hover:text-[#5a6a3a] transition-colors inline-block"
               >
                 {t.contact.urgentCta} →

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -177,9 +177,10 @@ export const dict = {
         phone: "+34 61 40 20 961",
         office: "Zaragoza, España",
       },
-      urgentTitle: "Need help urgently?",
-      urgentText: "Our on-call rotation handles critical incidents 24/7.",
-      urgentCta: "Page on-call",
+      urgentTitle: "Book a call to assess your needs",
+      urgentText:
+        "Schedule a free consultation and let's see how we can help you.",
+      urgentCta: "Book a call",
       toast: {
         success: "Message sent.",
         successDesc: "We'll reply within 24 hours.",
@@ -391,10 +392,10 @@ export const dict = {
         phone: "+34 61 40 20 961",
         office: "Zaragoza, España",
       },
-      urgentTitle: "¿Necesitas ayuda urgente?",
+      urgentTitle: "Agenda una cita para valorar tus necesidades",
       urgentText:
-        "Nuestra guardia 24/7 atiende incidentes críticos en cualquier momento.",
-      urgentCta: "Llamar a guardia",
+        "Reserva una consulta gratuita y vemos cómo podemos ayudarte.",
+      urgentCta: "Reservar cita",
       toast: {
         success: "Mensaje enviado.",
         successDesc: "Te responderemos en 24 horas.",


### PR DESCRIPTION
- Replace urgent mailto with Calendly scheduling link using new tab
- Update English urgent copy to highlight free consultation support
- Refresh Spanish urgent messaging to mirror consultation focus
- Align urgent contact flow with personalized assessment process