### PR TITLE
feat(newsletter): add confirmation flow handling

### DIFF
--- a/src/app/newsletter/confirm/page.tsx
+++ b/src/app/newsletter/confirm/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+type Status = "loading" | "success" | "error" | "missing_params";
+
+export default function NewsletterConfirmPage() {
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email") ?? "";
+  const token = searchParams.get("token") ?? "";
+  const name = searchParams.get("name") ?? "";
+
+  const [status, setStatus] = useState<Status>("loading");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    if (!email || !token) {
+      setStatus("missing_params");
+      return;
+    }
+
+    async function doConfirm() {
+      try {
+        const params = new URLSearchParams({ email, token });
+        if (name) params.set("name", name);
+        const res = await fetch(`${API_URL}/newsletter/confirm?${params.toString()}`);
+        if (res.ok) {
+          setStatus("success");
+        } else {
+          const body = await res.json().catch(() => ({}));
+          setErrorMsg(body.error ?? "Could not confirm your subscription.");
+          setStatus("error");
+        }
+      } catch {
+        setErrorMsg("Network error. Please try again later.");
+        setStatus("error");
+      }
+    }
+
+    doConfirm();
+  }, [email, token, name]);
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <div className="max-w-md w-full text-center space-y-6">
+        {status === "loading" && (
+          <>
+            <h1 className="text-2xl font-semibold">Confirming…</h1>
+            <p className="text-muted-foreground">
+              Please wait while we confirm your subscription.
+            </p>
+          </>
+        )}
+
+        {status === "success" && (
+          <>
+            <h1 className="text-2xl font-semibold">You're subscribed!</h1>
+            <p className="text-muted-foreground">
+              <strong>{email}</strong> is now confirmed. You'll start receiving
+              our newsletter.
+            </p>
+            <Button asChild variant="outline">
+              <Link href="/">Back to home</Link>
+            </Button>
+          </>
+        )}
+
+        {status === "error" && (
+          <>
+            <h1 className="text-2xl font-semibold">Something went wrong</h1>
+            <p className="text-muted-foreground">{errorMsg}</p>
+            <Button asChild variant="outline">
+              <Link href="/">Back to home</Link>
+            </Button>
+          </>
+        )}
+
+        {status === "missing_params" && (
+          <>
+            <h1 className="text-2xl font-semibold">Invalid link</h1>
+            <p className="text-muted-foreground">
+              This confirmation link appears to be invalid or incomplete.
+            </p>
+            <Button asChild variant="outline">
+              <Link href="/">Back to home</Link>
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/newsletter-section.tsx
+++ b/src/components/newsletter-section.tsx
@@ -31,7 +31,12 @@ export function NewsletterSection() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, name }),
       });
-      if (response.status === 201) {
+      if (response.status === 202) {
+        toast.success(t.newsletter.toast.confirm, {
+          description: t.newsletter.toast.confirmDesc,
+        });
+        setEmail("");
+      } else if (response.status === 201) {
         toast.success(t.newsletter.toast.success, {
           description: t.newsletter.toast.successDesc,
         });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -139,6 +139,8 @@ export const dict = {
       toast: {
         success: "Thanks for subscribing.",
         successDesc: "You'll receive our latest updates.",
+        confirm: "Almost there — check your inbox.",
+        confirmDesc: "We sent you a confirmation link. Click it to finish subscribing.",
         already: "You're already subscribed.",
         invalid: "Invalid email.",
         fail: "Something went wrong. Try again later.",
@@ -427,6 +429,8 @@ export const dict = {
       toast: {
         success: "¡Gracias por suscribirte!",
         successDesc: "Recibirás nuestras últimas novedades.",
+        confirm: "Casi listo — revisa tu correo.",
+        confirmDesc: "Te enviamos un enlace de confirmación. Haz clic para terminar de suscribirte.",
         already: "Ya estás suscrito.",
         invalid: "Correo inválido.",
         fail: "Algo salió mal. Inténtalo más tarde.",


### PR DESCRIPTION
- Introduce newsletter confirmation page that validates tokenized requests
- Handle loading, success, error, and missing parameter states with messaging
- Update subscription form to treat 202 responses as pending confirmation and reset input
- Extend i18n dictionaries with new confirmation toast copy for supported locales